### PR TITLE
Fix a bug in presentation generation

### DIFF
--- a/routes/report.rb
+++ b/routes/report.rb
@@ -1400,9 +1400,9 @@ get '/report/:id/presentation' do
     # add images into presentations
     @images = []
     @findings.each do |find|
-        a = {}
         if find.presentation_points
             find.presentation_points.to_s.split("<paragraph>").each do |pp|
+		a = {}
                 next unless pp =~ /\[\!\!/
                 img = pp.split("[!!")[1].split("!!]").first
                 a["name"] = img


### PR DESCRIPTION
There's a bug when you generate a presentation : in the case you have more than one attachment for one finding, all attachements' URL will point to the last added one.
So, if for exemple you add two attachments for one finding, you will see the same image for both attachment in your presentation.